### PR TITLE
Fix syntax errors in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,15 @@
 Glyph
 -----
-Glyph uses Machine Learning and Natural Language Processing to understand commit messages. This knowledge can be used for classifying commits into categories such as Bug-fixes, Feature additions, Improvements etc. 
 
-* Using Glyph with `Kebechet <https://github.com/thoth-station/kebechet>`_, smart CHANGELOG entries out of commit messages can be generated.
-* Glyph can also be used as a standlone library for analyzing commits from a locally stored repository (see usage below)
+Glyph uses Machine Learning and Natural Language Processing to understand
+commit messages. This knowledge can be used for classifying commits into
+categories such as Bug-fixes, Feature additions, Improvements etc. 
+
+* Using Glyph with `Kebechet <https://github.com/thoth-station/kebechet>`_,
+  smart CHANGELOG entries out of commit messages can be generated.
+
+* Glyph can also be used as a standlone library for analyzing commits from a
+  locally stored repository (see usage below)
 
 Running this project from Git
 =============================
@@ -26,28 +32,37 @@ This project is available on PyPI, to install it:
   pip install thoth-glyph
   
 Features
-=================================
-* **Commit Classification:** Singular commits can be classified using the following command:
-.. code-block:: console
+========
 
-  thoth-glyph classify -m "COMMIT MESSAGE TO BE ANALYZED"
+* **Commit Classification:** Singular commits can be classified using the
+  following command:
+
+  .. code-block:: console
+
+    thoth-glyph classify -m "COMMIT MESSAGE TO BE ANALYZED"
   
-* **Classifying Multiple Commits:** Mulitple commit can be classified together using the classify-repo command. By default, this action classifies all the commits in the repository. Optionally, a date-range (YYYY-MM-DD) can be provided:
-.. code-block:: console
+* **Classifying Multiple Commits:** Mulitple commit can be classified together
+  using the classify-repo command. By default, this action classifies all the
+  commits in the repository. Optionally, a date-range (YYYY-MM-DD) can be
+  provided:
 
-  thoth-glyph classify-repo --path /path/to/git/repo --start 2020-05-01 --end 2020-05-10
+  .. code-block:: console
   
-* **Classifying Using Tags:** Commits can also be picked using git tags. The following command will pick commits between the tags v3.7.1 and v3.7.2
-.. code-block:: console
+    thoth-glyph classify-repo --path /path/to/git/repo --start 2020-05-01 --end 2020-05-10
+  
+* **Classifying Using Tags:** Commits can also be picked using git tags. The
+  following command will pick commits between the tags v3.7.1 and v3.7.2
 
-  thoth-glyph classify-repo-by-tag --path /path/to/git/repo --start_tag v3.7.1 --end_tag v3.7.2
+  .. code-block:: console
+
+    thoth-glyph classify-repo-by-tag --path /path/to/git/repo --start_tag v3.7.1 --end_tag v3.7.2
   
 Sample Usage
-=================================
+============
 
 .. code-block:: console
 
-  [tussharm@tussharm glyph]$ thoth-glyph classify -m "Fixed server bug that impacted performance"
+  $ thoth-glyph classify -m "Fixed server bug that impacted performance"
   2020-08-12 19:45:47,798 4594 WARNING  thoth.common:346: Logging to a Sentry instance is turned off
   2020-08-12 19:45:47,799 4594 INFO     thoth.common:368: Logging to rsyslog endpoint is turned off
   2020-08-12 19:45:47,799 4594 INFO     glyph:68: Version: 0.0.0
@@ -57,7 +72,7 @@ Sample Usage
   
 .. code-block:: console
   
-  [tussharm@tussharm glyph]$ thoth-glyph classify-repo --path /home/tussharm/fork/glyph/ --start 2020-08-08 --end 2020-08-12
+  $ thoth-glyph classify-repo --path /home/tussharm/fork/glyph/ --start 2020-08-08 --end 2020-08-12
   2020-08-12 19:51:26,743 4873 WARNING  thoth.common:346: Logging to a Sentry instance is turned off
   2020-08-12 19:51:26,743 4873 INFO     thoth.common:368: Logging to rsyslog endpoint is turned off
   2020-08-12 19:51:26,744 4873 INFO     glyph:68: Version: 0.0.0
@@ -73,18 +88,30 @@ Sample Usage
   5  merge remote-tracking branch 'upstream/master'...         features
 
 Integration with Kebechet
-=================================
-Kebechet can use Glyph by reading the project's configuration from .thoth.yaml file. Glyph's supported formatters and ML classifers can be specified in this configuration file. 
+=========================
 
-* See sample manager configuration `here <https://github.com/thoth-station/kebechet/tree/master/kebechet/managers/version>`_
-* See sample changelog generated using Glyph `here <https://github.com/tushar7sharma/release-log-test/blob/master/SAMPLE_CHANGELOG.md>`_
+Kebechet can use Glyph by reading the project's configuration from .thoth.yaml
+file. Glyph's supported formatters and ML classifers can be specified in this
+configuration file. 
+
+* See sample manager configuration `here
+  <https://github.com/thoth-station/kebechet/tree/master/kebechet/managers/version>`__
+
+* See sample changelog generated using Glyph `here
+  <https://github.com/tushar7sharma/release-log-test/blob/master/SAMPLE_CHANGELOG.md>`__
 
 Model and Dataset
-=================================
-Currently Glyph ships with a model trained using Facebook's `fasttext <https://fasttext.cc/>`_ library over a dataset of ~5000 commits collected from multiple large-scale open source projects (see referred publications for more details). The library can be easily extended to accomodate more models. Developers are welcome to contribute and improve the classification accuracy.
+=================
+
+Currently Glyph ships with a model trained using Facebook's `fasttext
+<https://fasttext.cc/>`_ library over a dataset of ~5000 commits collected from
+multiple large-scale open source projects (see referred publications for more
+details). The library can be easily extended to accomodate more models.
+Developers are welcome to contribute and improve the classification accuracy.
 
 References
-=================================
+==========
+
 * https://arxiv.org/pdf/1711.05340.pdf
 * http://labsoft.dcc.ufmg.br/lib/exe/fetch.php?media=cibse-geanderson.pdf
 * https://github.com/gesteves91/fasttext-commit-classification


### PR DESCRIPTION
## Related Issues and Dependencies

```
Checking dist/thoth-glyph-0.1.0.tar.gz: FAILED
  `long_description` has syntax errors in markup and would not be rendered on PyPI.
```

## This introduces a breaking change

- [x] No
